### PR TITLE
ignore error and add block number

### DIFF
--- a/src/data/pools/poolData.ts
+++ b/src/data/pools/poolData.ts
@@ -6,6 +6,7 @@ import { PoolData } from 'state/pools/reducer'
 import { get2DayChange } from 'utils/data'
 import { formatTokenName, formatTokenSymbol } from 'utils/tokens'
 import { useActiveNetworkVersion, useClients } from 'state/application/hooks'
+import dayjs from 'dayjs'
 
 export const POOLS_BULK = (block: number | undefined, pools: string[]) => {
   let poolString = `[`
@@ -114,24 +115,35 @@ export function usePoolDatas(
 
   // get blocks from historic timestamps
   const [t24, t48, tWeek] = useDeltaTimestamps()
-  const { blocks, error: blockError } = useBlocksFromTimestamps([t24, t48, tWeek])
-  const [block24, block48, blockWeek] = blocks ?? []
+  const t0 = dayjs().unix()
+  const { blocks, error: blockError } = useBlocksFromTimestamps([t0, t24, t48, tWeek])
+  const [block0, block24, block48, blockWeek] = blocks ?? []
 
-  const { loading, error, data } = useQuery<PoolDataResponse>(POOLS_BULK(undefined, poolAddresses), {
+  const { loading, error, data } = useQuery<PoolDataResponse>(POOLS_BULK(block0?.number, poolAddresses), {
     client: dataClient,
+    errorPolicy: 'ignore',
   })
 
   const { loading: loading24, error: error24, data: data24 } = useQuery<PoolDataResponse>(
     POOLS_BULK(block24?.number, poolAddresses),
-    { client: dataClient }
+    {
+      client: dataClient,
+      errorPolicy: 'ignore',
+    }
   )
   const { loading: loading48, error: error48, data: data48 } = useQuery<PoolDataResponse>(
     POOLS_BULK(block48?.number, poolAddresses),
-    { client: dataClient }
+    {
+      client: dataClient,
+      errorPolicy: 'ignore',
+    }
   )
   const { loading: loadingWeek, error: errorWeek, data: dataWeek } = useQuery<PoolDataResponse>(
     POOLS_BULK(blockWeek?.number, poolAddresses),
-    { client: dataClient }
+    {
+      client: dataClient,
+      errorPolicy: 'ignore',
+    }
   )
 
   const anyError = Boolean(error || error24 || error48 || blockError || errorWeek)
@@ -154,6 +166,7 @@ export function usePoolDatas(
         return accum
       }, {})
     : {}
+
   const parsed24 = data24?.pools
     ? data24.pools.reduce((accum: { [address: string]: PoolFields }, poolData) => {
         accum[poolData.id] = poolData

--- a/src/data/pools/topPools.ts
+++ b/src/data/pools/topPools.ts
@@ -29,9 +29,11 @@ export function useTopPoolAddresses(): {
 } {
   const [currentNetwork] = useActiveNetworkVersion()
   const { dataClient } = useClients()
+
   const { loading, error, data } = useQuery<TopPoolsResponse>(TOP_POOLS, {
     client: dataClient,
     fetchPolicy: 'cache-first',
+    errorPolicy: 'ignore',
   })
 
   const formattedData = useMemo(() => {

--- a/src/data/tokens/tokenData.ts
+++ b/src/data/tokens/tokenData.ts
@@ -8,6 +8,7 @@ import { TokenData } from 'state/tokens/reducer'
 import { useEthPrices } from 'hooks/useEthPrices'
 import { formatTokenSymbol, formatTokenName } from 'utils/tokens'
 import { useActiveNetworkVersion, useClients } from 'state/application/hooks'
+import dayjs from 'dayjs'
 
 export const TOKENS_BULK = (block: number | undefined, tokens: string[]) => {
   let tokenString = `[`
@@ -76,19 +77,22 @@ export function useFetchedTokenDatas(
 
   // get blocks from historic timestamps
   const [t24, t48, tWeek] = useDeltaTimestamps()
+  const t0 = dayjs().unix()
 
-  const { blocks, error: blockError } = useBlocksFromTimestamps([t24, t48, tWeek])
-  const [block24, block48, blockWeek] = blocks ?? []
+  const { blocks, error: blockError } = useBlocksFromTimestamps([t0, t24, t48, tWeek])
+  const [block0, block24, block48, blockWeek] = blocks ?? []
   const ethPrices = useEthPrices()
 
-  const { loading, error, data } = useQuery<TokenDataResponse>(TOKENS_BULK(undefined, tokenAddresses), {
+  const { loading, error, data } = useQuery<TokenDataResponse>(TOKENS_BULK(block0?.number, tokenAddresses), {
     client: dataClient,
+    errorPolicy: 'ignore',
   })
 
   const { loading: loading24, error: error24, data: data24 } = useQuery<TokenDataResponse>(
     TOKENS_BULK(parseInt(block24?.number), tokenAddresses),
     {
       client: dataClient,
+      errorPolicy: 'ignore',
     }
   )
 
@@ -96,6 +100,7 @@ export function useFetchedTokenDatas(
     TOKENS_BULK(parseInt(block48?.number), tokenAddresses),
     {
       client: dataClient,
+      errorPolicy: 'ignore',
     }
   )
 
@@ -103,6 +108,7 @@ export function useFetchedTokenDatas(
     TOKENS_BULK(parseInt(blockWeek?.number), tokenAddresses),
     {
       client: dataClient,
+      errorPolicy: 'ignore',
     }
   )
 

--- a/src/data/tokens/topTokens.ts
+++ b/src/data/tokens/topTokens.ts
@@ -27,7 +27,10 @@ export function useTopTokenAddresses(): {
 } {
   const { dataClient } = useClients()
 
-  const { loading, error, data } = useQuery<TopTokensResponse>(TOP_TOKENS, { client: dataClient })
+  const { loading, error, data } = useQuery<TopTokensResponse>(TOP_TOKENS, {
+    client: dataClient,
+    errorPolicy: 'ignore',
+  })
 
   const formattedData = useMemo(() => {
     if (data) {


### PR DESCRIPTION
This should be a temporary solution, I believe the root cause should be from glodsky subgraph endpoint


1. ignore error so `data` field won't be empty when get "indexing_error"
2. add block number to current pool / token query, otherwise the `data` will also be empty